### PR TITLE
Update GeoNotificationManager.java

### DIFF
--- a/src/android/GeoNotificationManager.java
+++ b/src/android/GeoNotificationManager.java
@@ -46,8 +46,10 @@ public class GeoNotificationManager {
         for (GeoNotification geo : geoNotifications) {
             geoFences.add(geo.toGeofence());
         }
-        googleServiceCommandExecutor.QueueToExecute(new AddGeofenceCommand(
-                context, pendingIntent, geoFences));
+        if (!geoFences.isEmpty()) {
+        	googleServiceCommandExecutor.QueueToExecute(new AddGeofenceCommand(
+        			context, pendingIntent, geoFences));
+        }	
     }
 
     public List<GeoNotification> getWatched() {


### PR DESCRIPTION
When one adds some geofences and then removes all of them, upon every device reboot, the app crashes because the AddGeofenceCommand can't be called with geoFences list being empty. The exact error is "java.lang.IllegalArgumentException: At least one geofence must be specified."