### PR TITLE
Fix for iOS build

### DIFF
--- a/hooks/add_swift_support.js
+++ b/hooks/add_swift_support.js
@@ -49,6 +49,8 @@ module.exports = function(context) {
             console.log('IOS project Runpath Search Paths set to: @executable_path/Frameworks ...');
             console.log('IOS project Adding libsqlite3...');
             xcodeProject.addFramework("libsqlite3.dylib");
+
+            projectFile.write();
         });
     }
 


### PR DESCRIPTION
*This is a copy of https://github.com/cowbell/cordova-plugin-geofence/pull/22 with correct changeset now*

Concerning issue https://github.com/cowbell/cordova-plugin-geofence/issues/21

Undoing changes from commit https://github.com/cowbell/cordova-plugin-geofence/commit/c92ca1fa31888fc4b324e43bb8d8829a7f199458. The result is that the changes are not applied to the project anywhere, hence the iOS target release is not changed and the SQLITE dependency is not solved.

Reverting these changes solves the issue above, and the build succeeds.