### PR TITLE
Add missing namespace decleration for M2.

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
-<plugin xmlns="http://www.phonegap.com/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android" id="com.cowbell.cordova.geofence" version="0.3.3">
+<plugin xmlns="http://www.phonegap.com/ns/plugins/1.0" xmlns:m2="http://schemas.microsoft.com/appx/2013/manifest" xmlns:android="http://schemas.android.com/apk/res/android" id="com.cowbell.cordova.geofence" version="0.3.3">
     <name>geofence</name>
     <description>Geofence plugin</description>
     <license>Apache 2.0</license>


### PR DESCRIPTION
M2 was used in the Windows Phone section and validation XML validation.