### PR TITLE
Notify App So Transitions Can Be Handled In Native Code/Background As Well

### DIFF
--- a/src/ios/GeofencePlugin.swift
+++ b/src/ios/GeofencePlugin.swift
@@ -278,10 +278,7 @@ class GeoNotificationManager : NSObject, CLLocationManagerDelegate {
             }
             GeofencePlugin.fireReceiveTransition(geo)
 
-            let canCustomMethod = GeofencePluginWebView.respondsToSelector(Selector("customMethod"))
-
-            log("Custom Method Exists")
-            log(canCustomMethod)
+            NSNotificationCenter.defaultCenter().postNotificationName("handleTransition", object: geo);
         }
     }
 

--- a/src/ios/GeofencePlugin.swift
+++ b/src/ios/GeofencePlugin.swift
@@ -278,7 +278,7 @@ class GeoNotificationManager : NSObject, CLLocationManagerDelegate {
             }
             GeofencePlugin.fireReceiveTransition(geo)
 
-            NSNotificationCenter.defaultCenter().postNotificationName("handleTransition", object: geo);
+            NSNotificationCenter.defaultCenter().postNotificationName("handleTransition", object: geo.description)
         }
     }
 

--- a/src/ios/GeofencePlugin.swift
+++ b/src/ios/GeofencePlugin.swift
@@ -277,6 +277,11 @@ class GeoNotificationManager : NSObject, CLLocationManagerDelegate {
                 notifyAbout(geo)
             }
             GeofencePlugin.fireReceiveTransition(geo)
+
+            let canCustomMethod = GeofencePluginWebView.respondsToSelector(Selector("customMethod"))
+
+            log("Custom Method Exists")
+            log(canCustomMethod)
         }
     }
 


### PR DESCRIPTION
Implementation is for iOS only right now, Android will be coming soon.

The purpose of this enhancement is to allow transitions to also be handled in the background (potentially storing it for later, and then allowing the app to handle it when it is reopened, or to do some other custom action).

A notification was used to completely decouple the handling class from the plugin class. If the listener is not implemented then there are no compile issues. A string representation of the JSON object is passed to the notification because I needed to handle the notification in objective-c code and the JSON object couldn't be imported as is (compile issue with multiple constructors I think).

The following code can be added to the AppDelegate to handle a transition:

AppDelegate.h
-(void)handleTransitionListener:(NSNotification *) notification;

AppDelegate.m
-(void)handleTransitionListener:(NSNotification *) notification
{
    NSLog(@"handleTransitionListener heard the transition notification!");

```
NSString *strJSONTransition = (NSString *)notification.object;

NSLog(strJSONTransition);
```

}

And the following notification listener registration code needs to be added to init():
    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(handleTransitionListener:) name:@"handleTransition" object:nil];
