### PR TITLE
Added code to handle new cordova 5.0 structure

### DIFF
--- a/hooks/add_swift_support.js
+++ b/hooks/add_swift_support.js
@@ -25,20 +25,19 @@ module.exports = function(context) {
             xcodeProject,
             bridgingHeaderPath;
 
-		try
-		{
-			// try pre-5.0 cordova structure
-			platforms = context.requireCordovaModule('cordova-lib/src/plugman/platforms');
-			projectFile = platforms['ios'].parseProjectFile(iosPlatformPath);
-		} catch (e) {
-			console.log("Looks like we're in Cordova 5.0 and above...");
-			// let's try cordova 5.0 structure
-			platforms = context.requireCordovaModule('cordova-lib/src/plugman/platforms/ios');
-			projectFile = platforms.parseProjectFile(iosPlatformPath);
-		}
+        try {
+                // try pre-5.0 cordova structure
+                platforms = context.requireCordovaModule('cordova-lib/src/plugman/platforms');
+                projectFile = platforms['ios'].parseProjectFile(iosPlatformPath);
+        } catch (e) {
+                console.log("Looks like we're in Cordova 5.0 and above...");
+                // let's try cordova 5.0 structure
+                platforms = context.requireCordovaModule('cordova-lib/src/plugman/platforms/ios');
+                projectFile = platforms.parseProjectFile(iosPlatformPath);
+        }
 		
-		// hopefully projectFile can't go null here.......
-		xcodeProject = projectFile.xcode;
+        // hopefully projectFile can't go null here.......
+        xcodeProject = projectFile.xcode;
 		
         bridgingHeaderPath = getBridgingHeader(xcodeProject);
         if(bridgingHeaderPath) {

--- a/hooks/add_swift_support.js
+++ b/hooks/add_swift_support.js
@@ -15,16 +15,31 @@ module.exports = function(context) {
     function run(projectRoot) {
         var cordova_util = context.requireCordovaModule('cordova-lib/src/cordova/util'),
             ConfigParser = context.requireCordovaModule('cordova-lib/src/configparser/ConfigParser'),
-            platforms = context.requireCordovaModule('cordova-lib/src/plugman/platforms'),
+            platforms,
             xml = cordova_util.projectConfig(projectRoot),
             cfg = new ConfigParser(xml),
             projectName = cfg.name(),
             iosPlatformPath = path.join(projectRoot, 'platforms', 'ios'),
             iosProjectFilesPath = path.join(iosPlatformPath, projectName),
-            projectFile = platforms['ios'].parseProjectFile(iosPlatformPath),
-            xcodeProject = projectFile.xcode,
+            projectFile,
+            xcodeProject,
             bridgingHeaderPath;
 
+		try
+		{
+			// try pre-5.0 cordova structure
+			platforms = context.requireCordovaModule('cordova-lib/src/plugman/platforms');
+			projectFile = platforms['ios'].parseProjectFile(iosPlatformPath);
+		} catch (e) {
+			console.log("Looks like we're in Cordova 5.0 and above...");
+			// let's try cordova 5.0 structure
+			platforms = context.requireCordovaModule('cordova-lib/src/plugman/platforms/ios');
+			projectFile = platforms.parseProjectFile(iosPlatformPath);
+		}
+		
+		// hopefully projectFile can't go null here.......
+		xcodeProject = projectFile.xcode;
+		
         bridgingHeaderPath = getBridgingHeader(xcodeProject);
         if(bridgingHeaderPath) {
             bridgingHeaderPath = path.join(iosPlatformPath, bridgingHeaderPath);


### PR DESCRIPTION
hooks/add_swift_support.js will try to parse the Xcode project using the cordova pre-5.0 structure.  If that fails, it'll try cordova 5.0.  There were definitely some structural changes in 5.0.
