### PR TITLE
Added callback to initialize on Android

### DIFF
--- a/src/android/GeofencePlugin.java
+++ b/src/android/GeofencePlugin.java
@@ -66,6 +66,7 @@ public class GeofencePlugin extends CordovaPlugin {
                     .getWatched();
             callbackContext.success(Gson.get().toJson(geoNotifications));
         } else if (action.equals("initialize")) {
+            callbackContext.success();
 
         } else if (action.equals("deviceReady")) {
             deviceReady();


### PR DESCRIPTION
We want the plugin to be consistent on all platforms. This will allow me to set initialization this way:
```javascript
window.geofence.initialize(function(){
  // My initialization code
}, function(
  geofenceManager.log("Geofence: Unable to initialize geofence plugin.", error);
});
```
Instead of this way:
```javascript
if (ionic.Platform.isAndroid()) {
  _initializeGeofence();
} else {
  window.geofence.initialize(function(){
    _initializeGeofence();
  }, function(error){
    geofenceManager.log("Geofence: Unable to initialize geofence plugin.", error);
  });
}
     
function _initializeGeofence() {
  // My initialization code
}
```