### PR TITLE
update PromisesPlugin dependency id

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -19,7 +19,7 @@
         <clobbers target="geofence" />
     </js-module>
 
-    <dependency id="com.vladstirbu.cordova.promise" url="https://github.com/vstirbu/PromisesPlugin.git" />
+    <dependency id="es6-promise-plugin" url="https://github.com/vstirbu/PromisesPlugin.git" />
     <dependency id="android.support.v4" />
     <dependency id="com.google.playservices" />
 


### PR DESCRIPTION
The author of the [PromisesPlugin](https://github.com/vstirbu/PromisesPlugin.git) project has updated the ID of their plugin, thus causing issues on any projects dependent on this plugin (which cordova-plugin-geofence currently is). 

I noticed this when simply trying to add the cordova-plugin-geofence plugin to my cordova project:

cordova plugin add https://github.com/cowbell/cordova-plugin-geofence
Fetching plugin "https://github.com/cowbell/cordova-plugin-geofence" via git clone
Installing "cordova-plugin-geofence" for android
Fetching plugin "https://github.com/vstirbu/PromisesPlugin.git" via git clone
Failed to install 'cordova-plugin-geofence':Error: Expected fetched plugin to have ID "com.vladstirbu.cordova.promise" but got "es6-promise-plugin".
    at checkID (/usr/local/lib/node_modules/cordova/node_modules/cordova-lib/src/plugman/fetch.js:173:15)
    at /usr/local/lib/node_modules/cordova/node_modules/cordova-lib/src/plugman/fetch.js:94:17
    at _fulfilled (/usr/local/lib/node_modules/cordova/node_modules/q/q.js:787:54)
    at self.promiseDispatch.done (/usr/local/lib/node_modules/cordova/node_modules/q/q.js:816:30)
    at Promise.promise.promiseDispatch (/usr/local/lib/node_modules/cordova/node_modules/q/q.js:749:13)
    at /usr/local/lib/node_modules/cordova/node_modules/q/q.js:557:44
    at flush (/usr/local/lib/node_modules/cordova/node_modules/q/q.js:108:17)
    at process._tickCallback (node.js:419:13)
**Error: Expected fetched plugin to have ID "com.vladstirbu.cordova.promise" but got "es6-promise-plugin".**
    at checkID (/usr/local/lib/node_modules/cordova/node_modules/cordova-lib/src/plugman/fetch.js:173:15)
    at /usr/local/lib/node_modules/cordova/node_modules/cordova-lib/src/plugman/fetch.js:94:17
    at _fulfilled (/usr/local/lib/node_modules/cordova/node_modules/q/q.js:787:54)
    at self.promiseDispatch.done (/usr/local/lib/node_modules/cordova/node_modules/q/q.js:816:30)
    at Promise.promise.promiseDispatch (/usr/local/lib/node_modules/cordova/node_modules/q/q.js:749:13)
    at /usr/local/lib/node_modules/cordova/node_modules/q/q.js:557:44
    at flush (/usr/local/lib/node_modules/cordova/node_modules/q/q.js:108:17)
    at process._tickCallback (node.js:419:13)