### PR TITLE
Remove built-in initialize.

### DIFF
--- a/www/geofence.js
+++ b/www/geofence.js
@@ -135,13 +135,5 @@ function execPromise(success, error, pluginName, method, args) {
     });
 }
 
-
-// Called after 'deviceready' event
-channel.deviceready.subscribe(function () {
-    // Device is ready now, the listeners are registered
-    // and all queued events can be executed.
-    exec(null, null, 'GeofencePlugin', 'deviceReady', []);
-});
-
 geofence = new Geofence();
 module.exports = geofence;


### PR DESCRIPTION
Remove built-in initialization so that apps may start plugin at specific point rather than a forced initialize on app open.

Plugin currently forces prompt for location permissions on app open.  Users should call `geofence.initialize` on their own to define when to prompt for location permissions.