### PR TITLE
Fix for 'No geofence has been added to this request' OnConnected

### DIFF
--- a/src/android/AddGeofenceCommand.java
+++ b/src/android/AddGeofenceCommand.java
@@ -49,6 +49,7 @@ public class AddGeofenceCommand extends AbstractGoogleServiceCommand{
     public void ExecuteCustomCode() {
         // TODO Auto-generated method stub
         logger.log(Log.DEBUG, "Adding new geofences");
+        if(geofencesToAdd!=null && geofencesToAdd.size() > 0) {
         LocationServices.GeofencingApi
                 .addGeofences(mGoogleApiClient, geofencesToAdd, pendingIntent)
                 .setResultCallback(new ResultCallback<Status>() {
@@ -72,6 +73,7 @@ public class AddGeofenceCommand extends AbstractGoogleServiceCommand{
                         CommandExecuted();
                     }
                 });
+        }
     }
 
     @Override


### PR DESCRIPTION
only call addfences if fences are present (this method is called from OnConnected).