### PR TITLE
Draft Implementing wkwebview (Cordova ios 4)

### DIFF
--- a/src/ios/GeofencePlugin.swift
+++ b/src/ios/GeofencePlugin.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 import AudioToolbox
+import WebKit
 
 let TAG = "GeofencePlugin"
 let iOS8 = floor(NSFoundationVersionNumber) > floor(NSFoundationVersionNumber_iOS_7_1)
@@ -19,6 +20,7 @@ func log(message: String){
 
 @available(iOS 8.0, *)
 @objc(HWPGeofencePlugin) class GeofencePlugin : CDVPlugin {
+    var wk: WKWebView!
     lazy var geoNotificationManager = GeoNotificationManager()
     let priority = DISPATCH_QUEUE_PRIORITY_DEFAULT
 
@@ -145,8 +147,8 @@ func log(message: String){
     }
 
     func evaluateJs (script: String) {
-        if webView != nil {
-            webView!.stringByEvaluatingJavaScriptFromString(script)
+        if wk != nil {
+            wk!.evaluateJavaScript(script,completionHandler: nil)
         } else {
             log("webView is null")
         }


### PR DESCRIPTION
Qiuckly hacked something for this plugin to be compatible with wkwebview (using Ionic and Cordova iOs 4)

Going to need some extra work so as to cast WKWebView so it doesn't cause compiler error if WKWebView is not defined. Inspired by something like this (?) :


- (void)jsCallback: (NSString*)jsString
{
    if ([self.webView isKindOfClass:[UIWebView class]]) {
        [(UIWebView*)self.webView stringByEvaluatingJavaScriptFromString:jsString];
    }
    
    // TODO - find a way to conditionally cast WKWebView so it doesn't cause compiler error if WKWebView is not defined (iOS 7 / cordova-ios@3)
    /*else if([self.webView isKindOfClass:[WKWebView class]]) {
        [(WKWebView*)self.webView evaluateJavaScript:jsString completionHandler:nil];
    }*/
}