### PR TITLE
Add a weak reference to Webkit framework for iOS

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -133,5 +133,6 @@
         <source-file src="src/ios/SwiftData.swift"/>
         <source-file src="src/ios/SwiftyJson.swift"/>
         <framework src="libsqlite3.dylib"/>
+        <framework src="WebKit.framework" weak="true" />
     </platform>
 </plugin>


### PR DESCRIPTION
The `WKWebView` class is referenced in the code [here](https://github.com/cowbell/cordova-plugin-geofence/blob/master/src/ios/GeofencePlugin.swift#L173) which requires a weak link to the Webkit framework. Without said weak link Xcode fails the build during the linking phase with the error:
```
Undefined symbols for architecture arm64:
  "_OBJC_CLASS_$_WKWebView", referenced from:
      function signature specialization <Arg[0] = Owned To Guaranteed and Exploded> of Cordova500.GeofencePlugin.evaluateJs (Swift.String) -> () in GeofencePlugin.o
```