### PR TITLE
Add new iOS 11 plist key

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -122,6 +122,11 @@
             <string>$GEOFENCE_IN_USE_USAGE_DESCRIPTION</string>
         </config-file>
 
+        <preference name="GEOFENCE_ALWAYS_AND_IN_USE_USAGE_DESCRIPTION" default="${EXECUTABLE_NAME} Would Like to Use Your Current Location When In Use And Even In Background." />
+        <config-file target="*-Info.plist" parent="NSLocationAlwaysAndWhenInUseUsageDescription">
+            <string>$GEOFENCE_IN_USE_USAGE_DESCRIPTION</string>
+        </config-file>
+
 
         <config-file target="*-Info.plist" parent="UIBackgroundModes">
             <array>

--- a/plugin.xml
+++ b/plugin.xml
@@ -124,7 +124,7 @@
 
         <preference name="GEOFENCE_ALWAYS_AND_IN_USE_USAGE_DESCRIPTION" default="${EXECUTABLE_NAME} Would Like to Use Your Current Location When In Use And Even In Background." />
         <config-file target="*-Info.plist" parent="NSLocationAlwaysAndWhenInUseUsageDescription">
-            <string>$GEOFENCE_IN_USE_USAGE_DESCRIPTION</string>
+            <string>$GEOFENCE_ALWAYS_AND_IN_USE_USAGE_DESCRIPTION</string>
         </config-file>
 
 


### PR DESCRIPTION
iOS 11 introduced a new key that is required to allow an app Always location access. Without this key your app will only request While In Use access.