### PR TITLE
Add try-catch to avoid application crash for invalid geofence parameters (Android)

### DIFF
--- a/src/android/GeofencePlugin.java
+++ b/src/android/GeofencePlugin.java
@@ -69,30 +69,42 @@ public class GeofencePlugin extends CordovaPlugin {
 
         cordova.getThreadPool().execute(new Runnable() {
             public void run() {
-                if (action.equals("addOrUpdate")) {
-                    List<GeoNotification> geoNotifications = new ArrayList<GeoNotification>();
-                    for (int i = 0; i < args.length(); i++) {
-                        GeoNotification not = parseFromJSONObject(args.optJSONObject(i));
-                        if (not != null) {
-                            geoNotifications.add(not);
+                try {
+                    if (action.equals("addOrUpdate")) {
+                        List<GeoNotification> geoNotifications = new ArrayList<GeoNotification>();
+                        for (int i = 0; i < args.length(); i++) {
+                            GeoNotification not = parseFromJSONObject(args.optJSONObject(i));
+                            if (not != null) {
+                                geoNotifications.add(not);
+                            }
                         }
+                        geoNotificationManager.addGeoNotifications(geoNotifications, callbackContext);
+                    } else if (action.equals("remove")) {
+                        List<String> ids = new ArrayList<String>();
+                        for (int i = 0; i < args.length(); i++) {
+                            ids.add(args.optString(i));
+                        }
+                        geoNotificationManager.removeGeoNotifications(ids, callbackContext);
+                    } else if (action.equals("removeAll")) {
+                        geoNotificationManager.removeAllGeoNotifications(callbackContext);
+                    } else if (action.equals("getWatched")) {
+                        List<GeoNotification> geoNotifications = geoNotificationManager.getWatched();
+                        callbackContext.success(Gson.get().toJson(geoNotifications));
+                    } else if (action.equals("initialize")) {
+                        initialize(callbackContext);
+                    } else if (action.equals("deviceReady")) {
+                        deviceReady();
                     }
-                    geoNotificationManager.addGeoNotifications(geoNotifications, callbackContext);
-                } else if (action.equals("remove")) {
-                    List<String> ids = new ArrayList<String>();
-                    for (int i = 0; i < args.length(); i++) {
-                        ids.add(args.optString(i));
+                } catch (Exception e) {
+                    Log.w(TAG, "GeofencePlugin executing action: " + action + " args: " + args.toString(), e);
+                    try {
+                        JSONObject errorObject = new JSONObject();
+                        errorObject.put("message", e.toString());
+                        errorObject.put("code", ERROR_UNKNOWN);
+                        callbackContext.error(errorObject);
+                    } catch (JSONException exception) {
+                        callbackContext.error(e.toString());
                     }
-                    geoNotificationManager.removeGeoNotifications(ids, callbackContext);
-                } else if (action.equals("removeAll")) {
-                    geoNotificationManager.removeAllGeoNotifications(callbackContext);
-                } else if (action.equals("getWatched")) {
-                    List<GeoNotification> geoNotifications = geoNotificationManager.getWatched();
-                    callbackContext.success(Gson.get().toJson(geoNotifications));
-                } else if (action.equals("initialize")) {
-                    initialize(callbackContext);
-                } else if (action.equals("deviceReady")) {
-                    deviceReady();
                 }
             }
         });


### PR DESCRIPTION
Android application crashes if invalid latitude, longitude or radius is specified from geofence plugin JavaScript API.

For example:
```
window.geofence.addOrUpdate({id: "test", latitude: 91, longitude: 1, radius: 100, transitionType: 3});
```

Sample HTML/JS to reproduce crash:
https://gist.github.com/deton/d25afb2ae7ac794189c5550fc0edad45

logcat:
```
D/GeofencePlugin: GeofencePlugin execute action: addOrUpdate args: [{"id":"test","latitude":91,"longitude":1,"radius":100,"transitionType":3}]
                  
                  
                  --------- beginning of crash
E/AndroidRuntime: FATAL EXCEPTION: pool-1-thread-2
                  Process: io.github.deton.geofencetest, PID: 4338
                  java.lang.IllegalArgumentException: invalid latitude: 91.0
                      at com.google.android.gms.internal.zzcfs.<init>(Unknown Source)
                      at com.google.android.gms.location.Geofence$Builder.build(Unknown Source)
                      at com.cowbell.cordova.geofence.GeoNotification.toGeofence(GeoNotification.java:23)
                      at com.cowbell.cordova.geofence.GeoNotificationManager.addGeoNotifications(GeoNotificationManager.java:73)
                      at com.cowbell.cordova.geofence.GeofencePlugin$1.run(GeofencePlugin.java:80)
                      at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1113)
                      at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:588)
                      at java.lang.Thread.run(Thread.java:818)
```
