### PR TITLE
Don't display default icon in notification

### DIFF
--- a/src/android/Notification.java
+++ b/src/android/Notification.java
@@ -49,7 +49,7 @@ public class Notification {
             Uri uri = assets.parse(this.icon);
             bmp = assets.getIconFromUri(uri);
         } catch (Exception e){
-            bmp = assets.getIconFromDrawable(this.icon);
+            bmp = null;
         }
 
         return bmp;


### PR DESCRIPTION
If I don't want to show some icon, I don't specify it in javascript. So showing default icon is unnecessary and unwanted. 